### PR TITLE
Update immich_api.py

### DIFF
--- a/ppim-migrator/api/immich_api.py
+++ b/ppim-migrator/api/immich_api.py
@@ -30,7 +30,7 @@ class ImmichApi:
         self,
         albumName: str,
         assetIds = [],
-        description = f"Imported from photoprism ({datetime.datetime.now().strftime("%I:%M%p on %B %d, %Y")})",
+        description = f'Imported from photoprism ({datetime.datetime.now().strftime("%I:%M%p on %B %d, %Y")})',
     ) -> str:
         url = f"{self.base_url}/api/albums"
         payload = json.dumps(


### PR DESCRIPTION
Resolved SyntaxError: f-string: unmatched '('

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.10/dist-packages/ppim-migrator/__main__.py", line 2, in <module>
    from .migrator import Migrator
  File "/usr/local/lib/python3.10/dist-packages/ppim-migrator/migrator.py", line 2, in <module>
    from .api.immich_api import ImmichApi
  File "/usr/local/lib/python3.10/dist-packages/ppim-migrator/api/immich_api.py", line 33
    description = f"Imported from photoprism ({datetime.datetime.now().strftime("%I:%M%p on %B %d, %Y")})",
                                                                                 ^
SyntaxError: f-string: unmatched '('