### PR TITLE
Added notes to Configuration in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ immich:
   base_url: https://immich.example.com
   api_key: 
 ```
-
+Notes:
+* The PhotoPrism account must not have two factor authentication enabled
+* `base_url` must not end with a slash
+  
 ## Usage
 ### Migrate all favorites from photoprism to immich
 ```


### PR DESCRIPTION
Today I tried ppim-migrator and I ran into two things which prevented it from working:
* I added a trailing slash to the base_urls
* The photoprism account had two factor authentication enabled.

I added a note to the readme to prevent others running into the same issues.