### PR TITLE
Add support for migrating RAW jpg stacks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,9 @@
             "request": "launch",
             "module": "ppim-migrator",
             "args": [
-                "migrate-album",
-                "as6zq323u22kxvzb"
+                "migrate-stacked-raws"
+                //"migrate-album",
+                //"as6zq323u22kxvzb"
                 //"migrate-favorites"
                 // "migrate-all-albums",
                 // "--count=2"

--- a/ppim-migrator/__main__.py
+++ b/ppim-migrator/__main__.py
@@ -25,5 +25,11 @@ def migrate_all_albums(count):
     migrator = Migrator()
     migrator.migrate_all_albums(count)
 
+#migrate stacks
+@cli.command()
+def migrate_stacked_raws():
+    migrator = Migrator()
+    migrator.migrate_stacked_raws()
+
 if __name__ == "__main__":
     cli()

--- a/ppim-migrator/api/immich_api.py
+++ b/ppim-migrator/api/immich_api.py
@@ -59,3 +59,22 @@ class ImmichApi:
         }
         response = requests.request("PUT", url, headers=headers, data=payload)
         return response.text
+    
+    # POST /api/stacks
+    def create_stack(
+        self,
+        assetIds = [],
+    ) -> str:
+        url = f"{self.base_url}/api/stacks"
+        payload = json.dumps(
+            {
+                "assetIds": assetIds,
+            }
+        )
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "x-api-key": self.api_key,
+        }
+        response = requests.request("POST", url, headers=headers, data=payload)
+        return response.text

--- a/ppim-migrator/api/photoprism_api.py
+++ b/ppim-migrator/api/photoprism_api.py
@@ -60,6 +60,14 @@ class PhotoprismApi:
         response = requests.get(album_url, headers=headers)
         json_response = response.json()
         return json_response
+    
+    # GET /api/v1/photos?count=100000&stack=true&type=image|raw
+    def _get_raw_photos(self, count: int = 100000) -> list:
+        search_url = f"{self.base_url}/api/v1/photos?count={count}&type=raw&merged=true"
+        headers = {"X-Session-ID": self._get_session_id()}
+        response = requests.get(search_url, headers=headers)
+        json_response = response.json()
+        return json_response
 
     @staticmethod
     def _map_file_name(photos: list) -> list:
@@ -84,6 +92,20 @@ class PhotoprismApi:
         photos: list = self._get_photos_in_favorites(count)
         photos = self._filter_sidecar_files(photos)
         return self._map_file_name(photos)
+    
+    def get_raws_with_jpg_original(self, count: int = 100000) -> list:
+        photos: list = self._get_raw_photos(count)
+        photos_with_multiple_non_sidecar_files = [
+            item for item in photos if sum(1 for file in item["Files"] if file.get("Root") != "sidecar") > 1
+        ]       
+
+        raw_jpg_pairs = [ 
+            [file.get("Name") for file in item["Files"]] 
+            for item in photos_with_multiple_non_sidecar_files
+        ]  
+
+        # Get list of list of files 
+        return raw_jpg_pairs
 
     def get_album_title(self, uid: str) -> str:
         album_data = self._get_album_data(uid)

--- a/ppim-migrator/migrator.py
+++ b/ppim-migrator/migrator.py
@@ -16,6 +16,22 @@ class Migrator:
             config.config["immich"]["base_url"], config.config["immich"]["api_key"]
         )
 
+    def migrate_stacked_raws(self, count: int = 100000):
+        click.echo(f"Migrating all stacks (limit: {count})...")
+        jpg_raw_pairs = self.pp_api.get_raws_with_jpg_original(count)
+
+        for filelist in jpg_raw_pairs:
+            matching_uids = self._get_matching_uids(filelist)
+            matches_uids = matching_uids.get("uids")
+            files_not_found = matching_uids.get("files_not_found")
+            self._summary(matches_uids=matches_uids, files_not_found=files_not_found)
+
+            if(len(matches_uids) >= 2):
+                click.echo("Creating stack ...")
+                stack = self.im_api.create_stack(matches_uids)
+                click.echo(stack)
+
+
     def migrate_all_albums(self, count: int = 1000):
         click.echo(f"Migrating all albums (limit: {count})...")
         data = self.pp_api.get_all_albums_data(count)


### PR DESCRIPTION

Since Immich does not support auto stacking yet I added support for migrating these stacks. 
The API does not report the JPG+RAW stack as a stack, but this tool could also be used to migrate regular stacked images. 
I have not tested what would happen if you add another edited jpg with the same file name prefix (will test later).

Tested on my own library seems to work well with only raw+jpg combo.